### PR TITLE
Add typing_extensions dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license = {text = "Apache-2.0"}
 dependencies = [
     "pyarrow >= 12",
     "jsonschema",
+    "typing_extensions >= 4.0",
 ]
 
 [tool.isort]


### PR DESCRIPTION
https://github.com/Medical-Event-Data-Standard/meds/blob/main/src/meds/__init__.py includes the following import: 

`from typing_extensions import NotRequired, TypedDict`.

The import fails if `typing_extensions` isn't installed.

This is a quick change to add the missing dependency to `pyproject.toml`. 

