### PR TITLE
Run tests in the MEDS-ETL repository. Ref #8.

### DIFF
--- a/.github/workflows/meds-etl-test.yml
+++ b/.github/workflows/meds-etl-test.yml
@@ -38,6 +38,12 @@ jobs:
         cd meds_etl
         python -m pip install .
 
+    # Download MIMIC-IV-Demo (v2.2)
+    - name: Download MIMIC-IV-Demo (v2.2)
+      run: |
+        cd meds_etl
+        wget -r -N -c --no-host-directories --cut-dirs=1 -np -P tests/data https://physionet.org/files/mimic-iv-demo/2.2/
+
     # Run MEDS-ETL tests
     - name: Run MEDS-ETL tests
       run: |

--- a/.github/workflows/meds-etl-test.yml
+++ b/.github/workflows/meds-etl-test.yml
@@ -1,0 +1,45 @@
+name: Run MEDS-ETL tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    # Clone the MEDS-ETL repository
+    - name: Clone MEDS-ETL repository
+      run: git clone https://github.com/Medical-Event-Data-Standard/meds_etl.git
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+
+    # Install MEDS-ETL
+    - name: Install MEDS-ETL
+      run: |
+        cd meds_etl
+        python -m pip install .
+
+    # Run MEDS-ETL tests
+    - name: Run MEDS-ETL tests
+      run: |
+        cd meds_etl
+        pytest -v


### PR DESCRIPTION
The [MEDS-ETL repository](https://github.com/Medical-Event-Data-Standard/meds_etl/tree/main) is a downstream project that applies the MEDS schema in several demo ETL transforms. 

As mentioned in https://github.com/Medical-Event-Data-Standard/meds/issues/8, I think it would be worth running the MEDS-ETL tests here to ensure that any changes to MEDS do not break the MEDS-ETL.

This pull request adds a new workflow to run the MEDS-ETL tests. 