### PR TITLE
MEDS v2 Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Byte-compiled / optimized / DLL files
+_version.py
 __pycache__/
 *.py[cod]
 *$py.class

--- a/README.md
+++ b/README.md
@@ -10,16 +10,11 @@ The Python type signature for the schema is as follows:
 
 Patient = TypedDict('Patient', {
   'patient_id': int,
-  'static_measurements': List[Measurement],
   'events': List[Event],
 })
 
 Event = TypedDict('Event',{
-    'time': datetime.datetime,
-    'measurements': List[Measurement],
-})
-
-Measurement = TypedDict('Measurement', {
+    'time': NotRequired[datetime.datetime],
     'code': str,
     'text_value': NotRequired[str],
     'numeric_value': NotRequired[float],

--- a/src/meds/__init__.py
+++ b/src/meds/__init__.py
@@ -1,6 +1,6 @@
 from meds._version import __version__  # noqa
 
-from .schema import (patient_schema, Measurement, Event, Patient, label, Label,
+from .schema import (patient_schema, Event, Patient, label, Label,
                      code_metadata_entry, code_metadata, dataset_metadata,
                      CodeMetadataEntry, CodeMetadata, DatasetMetadata, birth_code,
                      death_code)
@@ -9,7 +9,6 @@ from .schema import (patient_schema, Measurement, Event, Patient, label, Label,
 # List all objects that we want to export
 _exported_objects = {
     'patient_schema': patient_schema,
-    'Measurement': Measurement,
     'Event': Event,
     'Patient': Patient,
     'label': label,

--- a/src/meds/schema.py
+++ b/src/meds/schema.py
@@ -21,6 +21,9 @@ from typing_extensions import NotRequired, TypedDict
 birth_code = "SNOMED/184099003"
 death_code = "SNOMED/419620001"
 
+# We define static events as always occurring on January 1st, 1 AD
+static_event_time = datetime.datetime(1, 1, 1)
+
 
 def patient_schema(per_event_properties_schema=pa.null()):
     # Return a patient schema with a particular per event metadata subschema

--- a/src/meds/schema.py
+++ b/src/meds/schema.py
@@ -49,7 +49,7 @@ def patient_schema(per_event_properties_schema=pa.null()):
 Event = TypedDict(
     "Event",
     {
-        "time": datetime.datetime,
+        "time": NotRequired[datetime.datetime],
         "code": str,
         "text_value": NotRequired[str],
         "numeric_value": NotRequired[float],

--- a/src/meds/schema.py
+++ b/src/meds/schema.py
@@ -21,14 +21,11 @@ from typing_extensions import NotRequired, TypedDict
 birth_code = "SNOMED/184099003"
 death_code = "SNOMED/419620001"
 
-# We define static events as always occurring on January 1st, 1 AD
-static_event_time = datetime.datetime(1, 1, 1)
-
 def patient_schema(per_event_properties_schema=pa.null()):
     # Return a patient schema with a particular per event metadata subschema
     event = pa.struct(
         [
-            pa.field("time", pa.timestamp("us"), nullable=False),
+            pa.field("time", pa.timestamp("us")), # Static events will have a null timestamp
             pa.field("code", pa.string(), nullable=False),
             pa.field("text_value", pa.string()),
             pa.field("numeric_value", pa.float32()),
@@ -40,7 +37,7 @@ def patient_schema(per_event_properties_schema=pa.null()):
     patient = pa.schema(
         [
             pa.field("patient_id", pa.int64(), nullable=False),
-            pa.field("events", pa.list_(event), nullable=False),  # Require ordered by time
+            pa.field("events", pa.list_(event), nullable=False),  # Require ordered by time, nulls must be first
         ]
     )
 

--- a/src/meds/schema.py
+++ b/src/meds/schema.py
@@ -32,6 +32,7 @@ def patient_schema(per_event_properties_schema=pa.null()):
             pa.field("code", pa.string(), nullable=False),
             pa.field("text_value", pa.string()),
             pa.field("numeric_value", pa.float32()),
+            pa.field("datetime_value", pa.timestamp("us")),
             pa.field("properties", per_event_properties_schema),
         ]
     )
@@ -55,6 +56,7 @@ Event = TypedDict(
         "code": str,
         "text_value": NotRequired[str],
         "numeric_value": NotRequired[float],
+        "datetime_value": NotRequired[datetime.datetime],
         "properties": NotRequired[Any],
     },
 )

--- a/src/meds/schema.py
+++ b/src/meds/schema.py
@@ -25,19 +25,19 @@ def patient_schema(per_event_properties_schema=pa.null()):
     # Return a patient schema with a particular per event metadata subschema
     event = pa.struct(
         [
-            pa.field("time", pa.timestamp("us")), # Static events will have a null timestamp
-            pa.field("code", pa.string(), nullable=False),
-            pa.field("text_value", pa.string()),
-            pa.field("numeric_value", pa.float32()),
-            pa.field("datetime_value", pa.timestamp("us")),
-            pa.field("properties", per_event_properties_schema),
+            ("time", pa.timestamp("us")), # Static events will have a null timestamp
+            ("code", pa.string()),
+            ("text_value", pa.string()),
+            ("numeric_value", pa.float32()),
+            ("datetime_value", pa.timestamp("us")),
+            ("properties", per_event_properties_schema),
         ]
     )
 
     patient = pa.schema(
         [
-            pa.field("patient_id", pa.int64(), nullable=False),
-            pa.field("events", pa.list_(event), nullable=False),  # Require ordered by time, nulls must be first
+            ("patient_id", pa.int64()),
+            ("events", pa.list_(event)),  # Require ordered by time, nulls must be first
         ]
     )
 

--- a/src/meds/schema.py
+++ b/src/meds/schema.py
@@ -22,24 +22,21 @@ birth_code = "SNOMED/184099003"
 death_code = "SNOMED/419620001"
 
 
-def patient_schema(per_event_metadata_schema=pa.null()):
+def patient_schema(per_event_properties_schema=pa.null()):
     # Return a patient schema with a particular per event metadata subschema
-    measurement = pa.struct(
+    event = pa.struct(
         [
+            ("time", pa.timestamp("us")),
             ("code", pa.string()),
             ("text_value", pa.string()),
             ("numeric_value", pa.float32()),
-            ("datetime_value", pa.timestamp("us")),
-            ("metadata", per_event_metadata_schema),
+            ("properties", per_event_properties_schema),
         ]
     )
-
-    event = pa.struct([("time", pa.timestamp("us")), ("measurements", pa.list_(measurement))])
 
     patient = pa.schema(
         [
             ("patient_id", pa.int64()),
-            ("static_measurements", pa.list_(measurement)),
             ("events", pa.list_(event)),  # Require ordered by time
         ]
     )
@@ -49,20 +46,18 @@ def patient_schema(per_event_metadata_schema=pa.null()):
 
 # Python types for the above schema
 
-Measurement = TypedDict(
-    "Measurement",
+Event = TypedDict(
+    "Event",
     {
+        "time": datetime.datetime,
         "code": str,
         "text_value": NotRequired[str],
         "numeric_value": NotRequired[float],
-        "datetime_value": NotRequired[datetime.datetime],
-        "metadata": NotRequired[Any],
+        "properties": NotRequired[Any],
     },
 )
 
-Event = TypedDict("Event", {"time": datetime.datetime, "measurements": List[Measurement]})
-
-Patient = TypedDict("Patient", {"patient_id": int, "static_measurements": List[Measurement], "events": List[Event]})
+Patient = TypedDict("Patient", {"patient_id": int, "events": List[Event]})
 
 ############################################################
 

--- a/src/meds/schema.py
+++ b/src/meds/schema.py
@@ -24,23 +24,22 @@ death_code = "SNOMED/419620001"
 # We define static events as always occurring on January 1st, 1 AD
 static_event_time = datetime.datetime(1, 1, 1)
 
-
 def patient_schema(per_event_properties_schema=pa.null()):
     # Return a patient schema with a particular per event metadata subschema
     event = pa.struct(
         [
-            ("time", pa.timestamp("us")),
-            ("code", pa.string()),
-            ("text_value", pa.string()),
-            ("numeric_value", pa.float32()),
-            ("properties", per_event_properties_schema),
+            pa.field("time", pa.timestamp("us"), nullable=False),
+            pa.field("code", pa.string(), nullable=False),
+            pa.field("text_value", pa.string()),
+            pa.field("numeric_value", pa.float32()),
+            pa.field("properties", per_event_properties_schema),
         ]
     )
 
     patient = pa.schema(
         [
-            ("patient_id", pa.int64()),
-            ("events", pa.list_(event)),  # Require ordered by time
+            pa.field("patient_id", pa.int64(), nullable=False),
+            pa.field("events", pa.list_(event), nullable=False),  # Require ordered by time
         ]
     )
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -15,22 +15,13 @@ def test_patient_schema():
     patient_data = [
         {
             "patient_id": 123,
-            "static_measurements": [{
-                "code": "some_static_code",
-                "text_value": "example",
-                "numeric_value": 1.0,
-                "datetime_value": datetime.datetime(2019, 1, 1, 0, 0, 0),
-                "metadata": None,
-            }],
             "events": [{  # Nested list for events
                 "time": datetime.datetime(2020, 1, 1, 12, 0, 0),
-                "measurements": [{  # Nested list for measurements
-                    "code": "some_code",
-                    "text_value": "Example",
-                    "numeric_value": 10.0,
-                    "datetime_value": datetime.datetime(2020, 1, 1, 12, 0, 0),
-                    "metadata": None
-                }]
+                "code": "some_code",
+                "text_value": "Example",
+                "numeric_value": 10.0,
+                "datetime_value": datetime.datetime(2020, 1, 1, 12, 0, 0),
+                "properties": None
             }]
         }
     ]


### PR DESCRIPTION
This commit creates the MEDS v2 release.

The MEDS v2 release makes two major changes to the MEDS format.

1. Switch from double nesting to single nesting, reducing the complexity of the schema and improving tooling support.

2. Rename of "metadata" to properties to avoid confusion with the dataset metadata.

Closes #21 and #20 
 