### PR TITLE
Major update of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This minimalist representation captures the essence of EHR data while providing 
 
 ## The Schemas
 
-MEDS is composed of five primary schema components:
+Building on this philosophy, MEDS defines five primary schema components:
 
 | **Component**         | **Description**                                                                                                                                                           | **Implementation** |
 |------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
@@ -55,13 +55,14 @@ MEDS is composed of five primary schema components:
 | `SubjectSplit`     | Stores information on how subjects are partitioned into subpopulations (e.g., training, tuning, held-out) for machine learning tasks.                                    | PyArrow schema                |
 | `Label`             | Defines the structure for labels that may be predicted about a subject at specific times in the subject record.                                                           | PyArrow schema                |
 
+
+Below, each schema is introduced in detail. Usage examples and a practical demonstration with the [MIMIC-IV demo](https://physionet.org/content/mimic-iv-demo/2.2/) dataset are provided in a later section.
+
 > [!Important]
-> Each component is implemented as a dataclass via the [`flexible_schema` package](https://github.com/Medical-Event-Data-Standard/flexible_schema) 
+> Each component is implemented as a dataclass via the [`flexible_schema`](https://github.com/Medical-Event-Data-Standard/flexible_schema) package 
 > to provide convenient validation functionality. Under the hood, these are standard PyArrow schemas (for tabular data) or 
 > JSON schemas (for single-entity metadata).
 
-
-Below, each schema is introduced in detail. Usage examples and a practical demonstration with the [MIMIC-IV demo dataset](https://physionet.org/content/mimic-iv-demo/2.2/) dataset are provided in a later section.
 
 
 ### The `Data` schema
@@ -98,7 +99,7 @@ The `DatasetMetadata` schema structures essential information about the source d
 It includes details such as the dataset’s name, version, and licensing, as well as specifics about the ETL process 
 used for transformation.
 
-The key fields defined in this schema are:
+The key fields defined in this schema are, all of which are optional:
 
 1. `dataset_name`: The name of the dataset.
 2. `dataset_version`: The version of the dataset.
@@ -111,8 +112,6 @@ The key fields defined in this schema are:
 9. `description_uri`: The URI containing a detailed description of the dataset.
 10. `extension_columns`: A list of additional columns present in the dataset beyond the core MEDS schema.
 
-
-`DatasetMetadata` is defined as a JSON schema, which can again be accessed via the `.schema()` method:
 
 ```python
 from meds import DatasetMetadata
@@ -140,13 +139,17 @@ DatasetMetadata.schema()
 
 This schema is intended to capture the complete context and provenance of the dataset. 
 A MEDS-compliant dataset should include this metadata to provide users with a clear understanding 
-of the data's origin and how it was transformed into the MEDS format.
+of the data's origin and how it was transformed into the MEDS format. Note that since this 
+schema is about a single entity, it is the only one defined as a JSON schema.
 
 
 ### The `CodeMetadata` schema
 
 The `CodeMetadata` schema provides additional details on how to describe the types of measurements (=codes) observed in the MEDS dataset. 
-It is designed to include metadata such as human-readable descriptions and ontological relationships for each code. Note that it is not guaranteed that all unique codes present in the dataset will be represented here—see [issue #57](https://github.com/Medical-Event-Data-Standard/meds/issues/57) for further discussion.
+It is designed to include metadata such as human-readable descriptions and ontological relationships for each code. 
+
+> [!Note]
+> It is not guaranteed that all unique codes present in the dataset will be represented here—see [issue #57](https://github.com/Medical-Event-Data-Standard/meds/issues/57) for further discussion.
 
 The core fields in this schema are:
 
@@ -266,7 +269,7 @@ data_subdirectory, dataset_metadata_filepath, code_metadata_filepath, subject_sp
 ('data', 'metadata/dataset.json', 'metadata/codes.parquet', 'metadata/subject_splits.parquet')
 ```
 
-> **Important:** MEDS data must satisfy two key properties:
+> [!Important] MEDS data must satisfy two key properties:
 >
 > 1. **Subject Contiguity:** Data for a single subject must not be split across multiple parquet files.
 > 2. **Sorted Order:** Data for a single subject must be contiguous within its file and sorted by time.

--- a/README.md
+++ b/README.md
@@ -487,3 +487,10 @@ pl.from_arrow(split_tbl)
 
 Note that label information is not included in the basic MIMIC-IV ETL, but you can find out more about how to create labels such as ICU mortality in the documentation of the [ACES package](https://eventstreamaces.readthedocs.io/en/latest/notebooks/examples.html).
 
+## Springboard
+Our website contains tutorials for getting started with MEDS and information about the current tools:
+- [Converting to MEDS](https://medical-event-data-standard.github.io/docs/tutorial-basics/converting_to_MEDS)
+- [Modeling over MEDS data](https://medical-event-data-standard.github.io/docs/tutorial-basics/modeling_over_MEDS_data)
+- [Public Research Resources](https://medical-event-data-standard.github.io/docs/MEDS_datasets_and_models)
+
+

--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@ Before we define the various schemas that make up MEDS, we will define some key 
 
 MEDS is composed of five primary schema components:
 
-| **Schema Component**         | **Description**                                                                                                                                                           | **Underlying Implementation** |
+| **Component**         | **Description**                                                                                                                                                           | **Implementation** |
 |------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
-| **Data Schema**              | Describes the core medical event data, organized as sequences of subject observations (i.e., events).                                                                       | PyArrow schema                |
-| **Dataset Metadata Schema**  | Captures metadata about the source dataset, including its name, version, and details of its conversion to MEDS (e.g., transformation time, ETL details).               | JSON schema                   |
-| **Code Metadata Schema**     | Provides metadata for the codes used to describe the types of measurements observed in the dataset.                                                                       | PyArrow schema                |
-| **Subject Split Schema**     | Stores information on how subjects are partitioned into subpopulations (e.g., training, tuning, held-out) for machine learning tasks.                                    | PyArrow schema                |
-| **Label Schema**             | Defines the structure for labels that may be predicted about a subject at specific times in the subject record.                                                           | PyArrow schema                |
+| `Data`              | Describes the core medical event data, organized as sequences of subject observations (i.e., events).                                                                       | PyArrow schema                |
+| `DatasetMetadata`  | Captures metadata about the source dataset, including its name, version, and details of its conversion to MEDS (e.g., transformation time, ETL details).               | JSON schema                   |
+| `CodeMetadata`     | Provides metadata for the codes used to describe the types of measurements observed in the dataset.                                                                       | PyArrow schema                |
+| `SubjectSplit`     | Stores information on how subjects are partitioned into subpopulations (e.g., training, tuning, held-out) for machine learning tasks.                                    | PyArrow schema                |
+| `Label`             | Defines the structure for labels that may be predicted about a subject at specific times in the subject record.                                                           | PyArrow schema                |
 
-> [!Note]
+> [!Important]
 > Each component is implemented as a dataclass via the [`flexible_schema` package](https://github.com/Medical-Event-Data-Standard/flexible_schema) 
 > to provide convenient validation functionality. Under the hood, these are standard PyArrow schemas (for tabular data) or 
 > JSON schemas (for single-entity metadata).
@@ -57,9 +57,9 @@ MEDS is composed of five primary schema components:
 Below, each schema is introduced in detail. Usage examples and a practical demonstration with the [MIMIC-IV demo dataset](https://physionet.org/content/mimic-iv-demo/2.2/) dataset are provided in a later section.
 
 
-### The data schema
+### The `Data` schema
 
-The _data_ schema describes the underlying medical data and defines four fields that will appear in every MEDS data file:
+The `Data` schema describes the underlying medical data and prescribes four fields that will appear in every MEDS data file:
 
 1. `subject_id`: The ID of the subject this event is about.
 2. `time`: The time of the event. This field is nullable for static events.
@@ -77,12 +77,13 @@ code: string
 numeric_value: float   
 ```
 
-In addition, it can contain any number of custom properties to further enrich observations. This is reflected
-programmatically using the [`flexible_schema`](https://github.com/Medical-Event-Data-Standard/flexible_schema) package as the below schema:
+In addition, a MEDS-compliant dataset can contain any number of custom columns to further enrich observations. 
+Examples of such columns include further ID columns such as `hadm_id` or `icustay_id` to uniquely identify events, 
+additional value types such as `text_value`, or additional metadata such as `ordercategorydescription`.
 
 
 
-### The dataset metadata schema
+### The `DatasetMetadata` schema
 
 The _dataset metadata_ schema documents important information about the underlying source dataset, including its name and version, 
 as well as details about its conversion to MEDS, such as when it was transformed, using what version of what code, etc.

--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ The `Data` schema describes a structure for the underlying medical data. It pres
 Under the hood, this just defines a PyArrow schema, which can be accessed via the `.schema()` method:
 
 ```python
->>> from meds import Data
->>> Data.schema()
+from meds import Data
+Data.schema()
+```
+```console
 subject_id: int64
 time: timestamp[us]
 code: string
@@ -103,11 +105,13 @@ The key fields defined in this schema are:
 10. `extension_columns`: A list of additional columns present in the dataset beyond the core MEDS schema.
 
 
-Under the hood, this just defines a JSON schema, which can again be accessed via the `.schema()` method:
+`DatasetMetadata` is defined as a JSON schema, which can again be accessed via the `.schema()` method:
 
 ```python
->>> from meds import DatasetMetadata
->>> DatasetMetadata.schema()
+from meds import DatasetMetadata
+DatasetMetadata.schema()
+```
+```console
 {
     'type': 'object', 
     'properties': {
@@ -144,8 +148,10 @@ The core fields in this schema are:
 3. `parent_codes`: A list of string identifiers for higher-level or parent codes in an ontological hierarchy. These may link to other codes in the file or external vocabularies (e.g., OMOP CDM).
 
 ```python
->>> from meds import CodeMetadata
->>> CodeMetadata.schema()
+from meds import CodeMetadata
+CodeMetadata.schema()
+```
+```console
 code: string
 description: string
 parent_codes: list<item: string>
@@ -164,8 +170,10 @@ The `SubjectSplit` schema defines how subjects were partitioned into groups for 
 
 
 ```python
->>> from meds import SubjectSplit
->>> SubjectSplit.schema()
+from meds import SubjectSplit
+SubjectSplit.schema()
+```
+```console
 subject_id: int64
 split: string
 ```
@@ -179,13 +187,11 @@ In line with common practice, MEDS defines three sentinel split names for conven
     this split should **not** be used for any purpose except final model validation.
 
 ```python
->>> from meds import train_split, tuning_split, held_out_split
->>> train_split
-'train'
->>> tuning_split 
-'tuning'
->>> held_out_split 
-'held_out'
+from meds import train_split, tuning_split, held_out_split
+train_split, tuning_split, held_out_split
+```
+```console
+('train', 'tuning', 'held_out')
 ```
 
 ### The `Label` schema
@@ -203,8 +209,10 @@ The key fields in the Label schema are:
 Like the other schemas, this is implemented as a PyArrow schema, and extra columns are not allowed.
 
 ```python
->>> from meds import Label
->>> Label.schema()
+from meds import Label
+Label.schema()
+```
+```console
 subject_id: int64
 prediction_time: timestamp[us]
 boolean_value: bool
@@ -239,21 +247,16 @@ A MEDS dataset is organized under a root directory (`$MEDS_ROOT`) into several s
 For ease of use, variables the expected file paths are predefined:
 
 ```python
->>> from meds.schema import (
-...     data_subdirectory,
-...     dataset_metadata_filepath,
-...     code_metadata_filepath,
-...     subject_splits_filepath
-... )
->>> 
->>> data_subdirectory
-'data'
->>> dataset_metadata_filepath
-'metadata/dataset.json'
->>> code_metadata_filepath
-'metadata/codes.parquet'
->>> subject_splits_filepath
-'metadata/subject_splits.parquet'
+from meds.schema import (
+    data_subdirectory,
+    dataset_metadata_filepath,
+    code_metadata_filepath,
+    subject_splits_filepath
+)
+data_subdirectory, dataset_metadata_filepath, code_metadata_filepath, subject_splits_filepath
+```
+```console
+('data', 'metadata/dataset.json', 'metadata/codes.parquet', 'metadata/subject_splits.parquet')
 ```
 
 > **Important:** MEDS data must satisfy two key properties:

--- a/README.md
+++ b/README.md
@@ -15,26 +15,19 @@ The Medical Event Data Standard (MEDS) is a data schema for storing streams of m
 sourced from either Electronic Health Records or claims records. For more information, tutorials, and
 compatible tools see the website: https://medical-event-data-standard.github.io/.
 
-## Terminology
+## Philosophy
 
-Before we define the various schemas that make up MEDS, we will define some key terminology that we use in this standard: 
+At the heart of MEDS is a simple yet powerful idea: nearly all EHR data can be modeled as a minimal tuple. We believe that the essence of a clinical event can be effectively described using three core components: 
 
-1. A _subject_ in a MEDS dataset is the primary entity being described by the sequences of care observations
-    in the underlying dataset. In most cases, _subjects_ will, naturally, be individuals, and the sequences
-    of care observations will cover all known observations about those individuals in a source health
-    datasets. However, in some cases, data may be organized so that we cannot describe all the data for an
-    individual reliably in a dataset, but instead can only describe subsequences of an individual's data,
-    such as in datasets that only link an individual's data observations together if they are within the same
-    hospital admission, regardless of how many admissions that individual has in the dataset (such as the
-    [eICU](https://eicu-crd.mit.edu/) dataset). In these cases, a _subject_ in the MEDS dataset may refer to
-    a hospital admission rather than an individual.
-2. A _code_ is the categorical descriptor of what is being observed in any given observation of a subject.
-    In particular, in almost all structured, longitudinal datasets, a measurement can be described as
-    consisting of a tuple containing a `subject_id` (who this measurement is about); a `time` (when this
-    measurement happened); some categorical qualifier describing what was measured, which we will call a
-    `code`; a value of a given type, such as a `numeric_value`, a `text_value`, or a `categorical_value`;
-    and possibly one or more additional measurement properties that describe the measurement in a
-    non-standardized manner.
+1. _subject_: The primary entity for which care observations are recorded. Typically, this is an individual with a complete sequence of observations. In some datasets (e.g., eICU), a subject may refer to a single hospital admission rather than the entire individual record.
+
+2. _time_: The time that the event was observed.
+
+3. _code_: The descriptor of what event is being observed.
+
+This minimalist representation captures the essence of EHR data while providing a consistent foundation for further analysis and enrichment.
+
+
 
 ## The Schemas
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img width="200" height="200" src="https://medical-event-data-standard.github.io/img/logo.svg" alt="MEDS Logo">
+</p>
+
 # Medical Event Data Standard
 
 [![PyPI - Version](https://img.shields.io/pypi/v/meds)](https://pypi.org/project/meds/)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ MEDS is composed of five primary schema components:
 | **Component**         | **Description**                                                                                                                                                           | **Implementation** |
 |------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
 | `Data`              | Describes the core medical event data, organized as sequences of subject observations (i.e., events).                                                                       | PyArrow schema                |
-| `DatasetMetadata`  | Captures metadata about the source dataset, including its name, version, and details of its conversion to MEDS (e.g., transformation time, ETL details).               | JSON schema                   |
+| `DatasetMetadata`  | Captures metadata about the source dataset, including its name, version, and details of its conversion to MEDS (e.g., ETL details).               | JSON schema                   |
 | `CodeMetadata`     | Provides metadata for the codes used to describe the types of measurements observed in the dataset.                                                                       | PyArrow schema                |
 | `SubjectSplit`     | Stores information on how subjects are partitioned into subpopulations (e.g., training, tuning, held-out) for machine learning tasks.                                    | PyArrow schema                |
 | `Label`             | Defines the structure for labels that may be predicted about a subject at specific times in the subject record.                                                           | PyArrow schema                |
@@ -59,7 +59,7 @@ Below, each schema is introduced in detail. Usage examples and a practical demon
 
 ### The `Data` schema
 
-The `Data` schema describes the underlying medical data and prescribes four fields that will appear in every MEDS data file:
+The `Data` schema describes a structure for the underlying medical data. It prescribes four fields that must appear in every MEDS data file:
 
 1. `subject_id`: The ID of the subject this event is about.
 2. `time`: The time of the event. This field is nullable for static events.
@@ -77,7 +77,7 @@ code: string
 numeric_value: float   
 ```
 
-In addition, a MEDS-compliant dataset can contain any number of custom columns to further enrich observations. 
+In addition, a MEDS-compliant data file can contain any number of custom columns to further enrich observations. 
 Examples of such columns include further ID columns such as `hadm_id` or `icustay_id` to uniquely identify events, 
 additional value types such as `text_value`, or additional metadata such as `ordercategorydescription`.
 
@@ -85,40 +85,23 @@ additional value types such as `text_value`, or additional metadata such as `ord
 
 ### The `DatasetMetadata` schema
 
-The _dataset metadata_ schema documents important information about the underlying source dataset, including its name and version, 
-as well as details about its conversion to MEDS, such as when it was transformed, using what version of what code, etc.
+The `DatasetMetadata` schema structures essential information about the source dataset and its conversion to MEDS. 
+It includes details such as the dataset’s name, version, and licensing, as well as specifics about the ETL process 
+used for transformation.
 
+The key fields defined in this schema are:
 
-```python
-class DatasetMetadata(JSONSchema):
-    """The schema for the dataset metadata file. Stored in `$MEDS_ROOT/metadata/dataset.json`.
+1. `dataset_name`: The name of the dataset.
+2. `dataset_version`: The version of the dataset.
+3. `etl_name`: The name of the ETL process that generated the MEDS dataset.
+4. `etl_version`: The version of the ETL process.
+5. `meds_version`: The version of the MEDS format used.
+6. `created_at`: The creation date and time (in ISO 8601 format).
+7. `license`: The license under which the dataset is released.
+8. `location_uri`: The URI where the dataset is hosted.
+9. `description_uri`: The URI containing a detailed description of the dataset.
+10. `extension_columns`: A list of additional columns present in the dataset beyond the core MEDS schema.
 
-    This is a JSON schema that has only optional fields.
-
-    Attributes:
-        dataset_name: The name of the dataset.
-        dataset_version: The version of the dataset.
-        etl_name: The name of the ETL process that generated the dataset.
-        etl_version: The version of the ETL process that generated the dataset.
-        meds_version: The version of the MEDS format.
-        created_at: The datetime the dataset was created. When serialized to JSON, is in ISO 8601 format.
-        license: The license for the dataset.
-        location_uri: The URI for the dataset location.
-        description_uri: The URI for the dataset description.
-        extension_columns: A list of columns in the data beyond those required in the core MEDS data schema.
-    """
-
-    dataset_name: Optional(str) = None
-    dataset_version: Optional(str) = None
-    etl_name: Optional(str) = None
-    etl_version: Optional(str) = None
-    meds_version: Optional(str) = None
-    created_at: Optional(datetime.datetime) = None
-    license: Optional(str) = None
-    location_uri: Optional(str) = None
-    description_uri: Optional(str) = None
-    extension_columns: Optional(list[str]) = None
-```
 
 Under the hood, this just defines a JSON schema, which can again be accessed via the `.schema()` method:
 
@@ -144,138 +127,90 @@ Under the hood, this just defines a JSON schema, which can again be accessed via
 }
 ```
 
+This schema is intended to capture the complete context and provenance of the dataset. 
+A MEDS-compliant dataset should include this metadata to provide users with a clear understanding 
+of the data's origin and how it was transformed into the MEDS format.
 
 
-### The code metadata schema.
+### The `CodeMetadata` schema
+
+The `CodeMetadata` schema provides additional details on how to describe the types of measurements (=codes) observed in the MEDS dataset. 
+It is designed to include metadata such as human-readable descriptions and ontological relationships for each code. Note that it is not guaranteed that all unique codes present in the dataset will be represented here—see [issue #57](https://github.com/Medical-Event-Data-Standard/meds/issues/57) for further discussion.
+
+The core fields in this schema are:
+
+1. `code`: A string representing the code for the event. This serves as the join key with the core MEDS data.
+2. `description`: A human-readable description of the code.
+3. `parent_codes`: A list of string identifiers for higher-level or parent codes in an ontological hierarchy. These may link to other codes in the file or external vocabularies (e.g., OMOP CDM).
 
 ```python
-class CodeMetadata(PyArrowSchema):
-    """The schema for the code metadata file. Stored in `$MEDS_ROOT/metadata/codes.parquet`.
-
-    This file contains additional details about the codes in the MEDS dataset. It is not guaranteed that all
-    unique codes in the dataset will be present in this file. See
-    https://github.com/Medical-Event-Data-Standard/meds/issues/57 if you would like to comment on this design
-    or advocate for mandating that all codes be present in this file.
-
-    This is a PyArrow schema that has
-        - 3 mandatory columns (`code`, `description`, `parent_codes`)
-        - Extra columns are allowed.
-
-    As with all PyArrow schemas, these columns may be null in the data.
-
-    Attributes:
-        code: The code for the event. This is a string (in an unspecified categorical vocabulary). This is a
-            join key with the core MEDS data.
-        description: A human-readable description of the code.
-        parent_codes: A list of string identifiers for "parents" of this code in an ontological sense. These
-            codes may link to other codes in the `codes.parquet` file or to external vocabularies. Most
-            typically, this is used to link to vocabularies in the OMOP CDM.
-    """
-
-    code: pa.string()
-    description: pa.string()
-    parent_codes: pa.list_(pa.string())
+>>> from meds import CodeMetadata
+>>> CodeMetadata.schema()
+code: string
+description: string
+parent_codes: list<item: string>
+  child 0, item: string
 ```
 
-### The subject split schema.
+As with the `Data` schema, the `CodeMetadata` schema can contain any number of custom columns to further describe the codes contained in the dataset.
 
-As soon as we want to perform any ML on the data, there are usually a couple of additional steps we need to take. One of the most common ones is to split the data into training, tuning, and held-out sets. 
 
-The _subject split_ schema is used to store these splits.
-In line with common practice, three sentinel split names are defined for convenience and shared processing:
+### The `SubjectSplit` schema
 
-1. A training split, named `train`, used for ML model training.
-2. A tuning split, named `tuning`, used for hyperparameter tuning. This is sometimes also called a
-    "validation" split or a "dev" split. In many cases, standardizing on a tuning split is not necessary and
-    models should feel free to merge this split with the training split if desired.
-3. A held-out split, named `held_out`, used for final model evaluation. In many cases, this is also called a
-    "test" split. When performing benchmarking, this split should not be used at all for model selection,
-    training, or for any purposes up to final validation.
+The `SubjectSplit` schema defines how subjects were partitioned into groups for machine learning tasks. This schema consists of two mandatory fields:
 
-Additional split names can be used by the user as desired.
+1. `subject_id`: The ID of the subject. This serves as the join key with the core MEDS data.
+2. `split`: The name of the assigned split.
+
 
 ```python
-train_split = "train"
-tuning_split = "tuning"
-held_out_split = "held_out"
-
-
-class SubjectSplit(PyArrowSchema):
-    """The schema for storing per-subject splits. Stored in `$MEDS_ROOT/metadata/subject_splits.parquet`.
-
-    The subject splits are used to divide the subjects into training, tuning, and held-out sets at a
-    per-subject level. Per-subject splits are currently the only supported split format in MEDS. Additional
-    types of splits may be added in the future; see
-    https://github.com/Medical-Event-Data-Standard/meds/issues/74 for more information and to contribute to
-    the discussion on this point.
-
-    We use the following default split names:
-        - `train`: For training the model.
-        - `tuning`: For hyperparameter tuning, early stopping, etc. This is also commonly called the
-          "validation" or "dev" set.
-        - `held_out`: For final evaluation of the model. This is also commonly called the "test" set.
-
-    This is a PyArrow schema that has
-        - 2 mandatory columns (`subject_id`, `split`)
-        - Extra columns are not allowed.
-
-    Attributes:
-        subject_id: The unique identifier for the subject. This is a 64-bit integer. This field is a join key
-            with the core MEDS data.
-        split: The split for the subject. This is a string. Any value is permissible. The sentinel values of
-            "train", "tuning", and "held_out" are recommended for training, tuning, and held-out sets.
-    """
-
-    allow_extra_columns: ClassVar[bool] = False
-
-    subject_id: pa.int64()
-    split: pa.string()
+>>> from meds import SubjectSplit
+>>> SubjectSplit.schema()
+subject_id: int64
+split: string
 ```
 
+In line with common practice, MEDS defines three sentinel split names for convenience and shared processing:
 
-
-### The label schema.
-
-Finally
-
-Models, when predicting this label, are allowed to use all data about a subject up to and including the
-prediction time. Exclusive prediction times are not currently supported, but if you have a use case for them
-please add a GitHub issue.
+1. `train`: For model training.
+2. `tuning`: For hyperparameter tuning (often referred to alternatively as the "validation" or "dev" set). 
+    In many cases, a tuning split may not be necessary and can be merged with the training set.
+3. `held_out`: For final model evaluation (also commonly called the "test" set). When performing benchmarking, 
+    this split should **not** be used for any purpose except final model validation.
 
 ```python
-class Label(PyArrowSchema):
-    """The label-file schema for MEDS. No dedicated storage path, but stored with parquet files.
+>>> from meds import train_split, tuning_split, held_out_split
+>>> train_split
+'train'
+>>> tuning_split 
+'tuning'
+>>> held_out_split 
+'held_out'
+```
 
-    This schema may or may not be sharded, and may or may not reflect the same sharding as the core MEDS
-    dataset.
+### The `Label` schema
 
-    This is a PyArrow schema that has
-      - 2 mandatory columns (`subject_id`, `prediction_time`)
-      - 4 optional columns (`boolean_value`, `integer_value`, `float_value`, `categorical_value`). These
-        represent the "labels" for the subject at the prediction time.
-      - Extra columns are not allowed.
+The `Label` schema specifies the structure for labels that may be predicted about a subject at a given time. Models can use all data for a subject up to and including the prediction time (exclusive prediction times are not supported; please open a GitHub issue if needed).
 
-    Attributes:
-        subject_id: The unique identifier for the subject. This is a 64-bit integer. This field is a join key
-            with the core MEDS data.
-        prediction_time: When predicting the given label for the subject, data may be used from this subject
-            up to and including this time. This is a timestamp with microsecond precision.
-        boolean_value: A boolean label for the subject at the prediction time. Used for binary classification.
-        integer_value: An integer label for the subject at the prediction time. Used for multi-class
-            classification or ordinal regression.
-        float_value: A float label for the subject at the prediction time. Used for regression.
-        categorical_value: A string label for the subject at the prediction time. Used for multi-class
-            classification.
-    """
+The key fields in the Label schema are:
+1. `subject_id`: The ID of the subject. This serves as the join key with the core MEDS data.
+2. `prediction_time`: The time of the prediction. This field is nullable for static labels.
+3. `boolean_value`: The boolean value of the label. This field is nullable for non-boolean labels.
+4. `integer_value`: The integer value of the label. This field is nullable for non-integer labels.
+5. `float_value`: The float value of the label. This field is nullable for non-float labels.
+6. `categorical_value`: The categorical value of the label. This field is nullable for non-categorical labels.
 
-    allow_extra_columns: ClassVar[bool] = False
+Like the other schemas, this is implemented as a PyArrow schema, and extra columns are not allowed.
 
-    subject_id: pa.int64()
-    prediction_time: pa.timestamp("us")  # noqa: F821 -- this seems to be a flake error
-    boolean_value: Optional(pa.bool_()) = None
-    integer_value: Optional(pa.int64()) = None
-    float_value: Optional(pa.float32()) = None
-    categorical_value: Optional(pa.string()) = None
+```python
+>>> from meds import Label
+>>> Label.schema()
+subject_id: int64
+prediction_time: timestamp[us]
+boolean_value: bool
+integer_value: int64
+float_value: float
+categorical_value: string
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@
 ![The MEDS data schema](static/data_figure.svg)
 
 The Medical Event Data Standard (MEDS) is a data schema for storing streams of medical events, often
-sourced from either Electronic Health Records or claims records. Before we define the various schema that make
-up MEDS, we will define some key terminology that we use in this standard. For more information, tutorials, and
+sourced from either Electronic Health Records or claims records. For more information, tutorials, and
 compatible tools see the website: https://medical-event-data-standard.github.io/.
 
 ## Terminology
+
+Before we define the various schemas that make up MEDS, we will define some key terminology that we use in this standard: 
 
 1. A _subject_ in a MEDS dataset is the primary entity being described by the sequences of care observations
     in the underlying dataset. In most cases, _subjects_ will, naturally, be individuals, and the sequences
@@ -35,66 +36,26 @@ compatible tools see the website: https://medical-event-data-standard.github.io/
     and possibly one or more additional measurement properties that describe the measurement in a
     non-standardized manner.
 
-## Core MEDS Data Organization
+## The Schemas
 
-MEDS consists of four main data components/schemas:
+MEDS consists of five components/schemas:
 
-1. A _data schema_. This schema describes the underlying medical data, organized as sequences of subject
-    observations, in the dataset.
-2. A _subject subsequence label schema_. This schema describes labels that may be predicted about a subject
-    at a given time in the subject record.
-3. A _code metadata schema_. This schema contains metadata describing the codes used to categorize the
-    observed measurements in the dataset.
-4. A _dataset metadata schema_. This schema contains metadata about the MEDS dataset itself, such as when it
-    was produced, using what version of what code, etc.
-5. A _subject split schema_. This schema contains metadata about how subjects in the MEDS dataset are
+1. A _data_ schema. This schema describes the underlying medical data, organized as sequences of subject
+    observations.
+2. A _dataset metadata_ schema. This schema contains metadata about the source dataset, such as its name and versions, and its conversion to MEDS, such as when it was transformed, using what version of what code, etc.
+3. A _code metadata_ schema. This schema contains metadata describing the codes used to describe the
+    types of measurements observed in the dataset.
+4. A _subject split_ schema. This schema contains metadata about how subjects in the MEDS dataset are
     assigned to different subpopulations, most commonly used to dictate ML splits.
+5. A _label_ schema. This schema describes labels that may be predicted about a subject
+    at a given time in the subject record.
 
-### Organization on Disk
+Below, each of these schemas are introduced in detail. Throughout this document, we will use the publicly available [MIMIC-IV demo dataset](https://physionet.org/content/mimic-iv-demo/2.2/) and [its conversion to MEDS](https://github.com/Medical-Event-Data-Standard/MIMIC_IV_MEDS) as a concrete example to see how these schemas might be used in practice.
 
-Given a MEDS dataset stored in the `$MEDS_ROOT` directory data of the various schemas outlined above can be
-found in the following subfolders:
 
-- `$MEDS_ROOT/data/`: This directory will contain data in the _data schema_, organized as a
-    series of possibly nested sharded dataframes stored in `parquet` files. In particular, the file glob
-    `glob("$MEDS_ROOT/data/**/*.parquet)` will capture all sharded data files of the raw MEDS data, all
-    organized into _data schema_ files, sharded by subject and sorted, for each subject, by
-    time.
-- `$MEDS_ROOT/metadata/codes.parquet`: This file contains per-code metadata in the _code metadata schema_
-    about the MEDS dataset. All codes within the dataset should have an entry in this file.
-    As this dataset describes all codes observed in the full MEDS dataset, it is _not_
-    sharded. Note that some pre-processing operations may, at times, produce sharded code metadata files, but
-    these will always appear in subdirectories of `$MEDS_ROOT/metadata/` rather than at the top level, and
-    should generally not be used for overall metadata operations.
-- `$MEDS_ROOT/metadata/dataset.json`: This schema contains metadata in the _dataset metadata schema_ about
-    the dataset and its production process.
-- `$MEDS_ROOT/metadata/subject_splits.parquet`: This schema contains information in the _subject split
-    schema_ about what splits different subjects are in.
+### The data schema
 
-Task label dataframes are stored in the `label_schema`, in a file path that depends on both a
-`$TASK_ROOT` directory where task label dataframes are stored and a `$TASK_NAME` parameter that separates
-different tasks from one another. In particular, the file glob `glob($TASK_ROOT/$TASK_NAME/**/*.parquet)` will
-retrieve a sharded set of dataframes in the `label_schema` where the sharding may or may not match up with
-the sharding used in the raw `$MEDS_ROOT/data/**/*.parquet` files (e.g., the file
-`$TASK_ROOT/$TASK_NAME/$SHARD_NAME.parquet` may cover the labels for the same set of subjects as are
-contained in the raw data file at `$MEDS_ROOT/data/**/*.parquet`). Note that (1) `$TASK_ROOT` may be a subdir
-of `$MEDS_ROOT` (e.g., often `$TASK_ROOT` will be set to `$MEDS_ROOT/tasks`), (2) `$TASK_NAME` may have `/`s
-in it, thereby rendering the task label directory a deep, nested subdir of `$TASK_ROOT`, and (3) in some
-cases, there may be no task labels for a shard of the raw data, if no subject in that shard qualifies for that
-task, in which case it may be true that either `$TASK_ROOT/$TASK_NAME/$SHARD_NAME.parquet` is empty or that it
-does not exist.
-
-### Schemas
-
-#### The Data Schema
-
-MEDS data also must satisfy two important properties:
-
-1. Data about a single subject cannot be split across parquet files. If a subject is in a dataset it must be
-    in one and only one parquet file.
-2. Data about a single subject must be contiguous within a particular parquet file and sorted by time.
-
-The data schema has four fields that will appear in every MEDS dataset data file:
+The _data_ schema describes the underlying medical data and defines four fields that will appear in every MEDS data file:
 
 1. `subject_id`: The ID of the subject this event is about.
 2. `time`: The time of the event. This field is nullable for static events.
@@ -134,42 +95,172 @@ class Data(PyArrowSchema):
     numeric_value: Optional(pa.float32()) = None
 ```
 
-This schema can be used to generate the mandatory schema elements and/or validate or enforce a compliant MEDS
-schema via the `.validate()` method:
+Under the hood, this just defines a PyArrow schema, which can be accessed via the `.schema()` method:
 
 ```python
->>> import pyarrow as pa
->>> import datetime
 >>> from meds import Data
 >>> Data.schema()
 subject_id: int64
 time: timestamp[us]
 code: string
-numeric_value: float
->>> data_tbl = pa.Table.from_pydict({
-...     "code": ["A", "B", "C"],
-...     "subject_id": [1, 2, 3],
-...     "time": [
-...         datetime.datetime(2021, 3, 1),
-...         datetime.datetime(2021, 4, 1),
-...         datetime.datetime(2021, 5, 1),
-...     ],
-... })
->>> Data.validate(data_tbl)
-pyarrow.Table
-subject_id: int64
-time: timestamp[us]
-code: string
-numeric_value: float
-----
-subject_id: [[1,2,3]]
-time: [[2021-03-01 00:00:00.000000,2021-04-01 00:00:00.000000,2021-05-01 00:00:00.000000]]
-code: [["A","B","C"]]
-numeric_value: [[null,null,null]]
-
+numeric_value: float   
 ```
 
-#### The label schema.
+
+### The dataset metadata schema
+
+The _dataset metadata_ schema documents important information about the underlying source dataset, including its name and version, 
+as well as details about its conversion to MEDS, such as when it was transformed, using what version of what code, etc.
+
+
+```python
+class DatasetMetadata(JSONSchema):
+    """The schema for the dataset metadata file. Stored in `$MEDS_ROOT/metadata/dataset.json`.
+
+    This is a JSON schema that has only optional fields.
+
+    Attributes:
+        dataset_name: The name of the dataset.
+        dataset_version: The version of the dataset.
+        etl_name: The name of the ETL process that generated the dataset.
+        etl_version: The version of the ETL process that generated the dataset.
+        meds_version: The version of the MEDS format.
+        created_at: The datetime the dataset was created. When serialized to JSON, is in ISO 8601 format.
+        license: The license for the dataset.
+        location_uri: The URI for the dataset location.
+        description_uri: The URI for the dataset description.
+        extension_columns: A list of columns in the data beyond those required in the core MEDS data schema.
+    """
+
+    dataset_name: Optional(str) = None
+    dataset_version: Optional(str) = None
+    etl_name: Optional(str) = None
+    etl_version: Optional(str) = None
+    meds_version: Optional(str) = None
+    created_at: Optional(datetime.datetime) = None
+    license: Optional(str) = None
+    location_uri: Optional(str) = None
+    description_uri: Optional(str) = None
+    extension_columns: Optional(list[str]) = None
+```
+
+Under the hood, this just defines a JSON schema, which can again be accessed via the `.schema()` method:
+
+```python
+>>> from meds import DatasetMetadata
+>>> DatasetMetadata.schema()
+{
+    'type': 'object', 
+    'properties': {
+        'dataset_name': {'type': 'string'}, 
+        'dataset_version': {'type': 'string'}, 
+        'etl_name': {'type': 'string'}, 
+        'etl_version': {'type': 'string'}, 
+        'meds_version': {'type': 'string'}, 
+        'created_at': {'type': 'string', 'format': 'date-time'}, 
+        'license': {'type': 'string'}, 
+        'location_uri': {'type': 'string'}, 
+        'description_uri': {'type': 'string'}, 
+        'extension_columns': {'type': 'array', 'items': {'type': 'string'}}
+    }, 
+    'required': [], 
+    'additionalProperties': True
+}
+```
+
+
+
+### The code metadata schema.
+
+```python
+class CodeMetadata(PyArrowSchema):
+    """The schema for the code metadata file. Stored in `$MEDS_ROOT/metadata/codes.parquet`.
+
+    This file contains additional details about the codes in the MEDS dataset. It is not guaranteed that all
+    unique codes in the dataset will be present in this file. See
+    https://github.com/Medical-Event-Data-Standard/meds/issues/57 if you would like to comment on this design
+    or advocate for mandating that all codes be present in this file.
+
+    This is a PyArrow schema that has
+        - 3 mandatory columns (`code`, `description`, `parent_codes`)
+        - Extra columns are allowed.
+
+    As with all PyArrow schemas, these columns may be null in the data.
+
+    Attributes:
+        code: The code for the event. This is a string (in an unspecified categorical vocabulary). This is a
+            join key with the core MEDS data.
+        description: A human-readable description of the code.
+        parent_codes: A list of string identifiers for "parents" of this code in an ontological sense. These
+            codes may link to other codes in the `codes.parquet` file or to external vocabularies. Most
+            typically, this is used to link to vocabularies in the OMOP CDM.
+    """
+
+    code: pa.string()
+    description: pa.string()
+    parent_codes: pa.list_(pa.string())
+```
+
+### The subject split schema.
+
+As soon as we want to perform any ML on the data, there are usually a couple of additional steps we need to take. One of the most common ones is to split the data into training, tuning, and held-out sets. 
+
+The _subject split_ schema is used to store these splits.
+In line with common practice, three sentinel split names are defined for convenience and shared processing:
+
+1. A training split, named `train`, used for ML model training.
+2. A tuning split, named `tuning`, used for hyperparameter tuning. This is sometimes also called a
+    "validation" split or a "dev" split. In many cases, standardizing on a tuning split is not necessary and
+    models should feel free to merge this split with the training split if desired.
+3. A held-out split, named `held_out`, used for final model evaluation. In many cases, this is also called a
+    "test" split. When performing benchmarking, this split should not be used at all for model selection,
+    training, or for any purposes up to final validation.
+
+Additional split names can be used by the user as desired.
+
+```python
+train_split = "train"
+tuning_split = "tuning"
+held_out_split = "held_out"
+
+
+class SubjectSplit(PyArrowSchema):
+    """The schema for storing per-subject splits. Stored in `$MEDS_ROOT/metadata/subject_splits.parquet`.
+
+    The subject splits are used to divide the subjects into training, tuning, and held-out sets at a
+    per-subject level. Per-subject splits are currently the only supported split format in MEDS. Additional
+    types of splits may be added in the future; see
+    https://github.com/Medical-Event-Data-Standard/meds/issues/74 for more information and to contribute to
+    the discussion on this point.
+
+    We use the following default split names:
+        - `train`: For training the model.
+        - `tuning`: For hyperparameter tuning, early stopping, etc. This is also commonly called the
+          "validation" or "dev" set.
+        - `held_out`: For final evaluation of the model. This is also commonly called the "test" set.
+
+    This is a PyArrow schema that has
+        - 2 mandatory columns (`subject_id`, `split`)
+        - Extra columns are not allowed.
+
+    Attributes:
+        subject_id: The unique identifier for the subject. This is a 64-bit integer. This field is a join key
+            with the core MEDS data.
+        split: The split for the subject. This is a string. Any value is permissible. The sentinel values of
+            "train", "tuning", and "held_out" are recommended for training, tuning, and held-out sets.
+    """
+
+    allow_extra_columns: ClassVar[bool] = False
+
+    subject_id: pa.int64()
+    split: pa.string()
+```
+
+
+
+### The label schema.
+
+Finally
 
 Models, when predicting this label, are allowed to use all data about a subject up to and including the
 prediction time. Exclusive prediction times are not currently supported, but if you have a use case for them
@@ -211,90 +302,90 @@ class Label(PyArrowSchema):
     categorical_value: Optional(pa.string()) = None
 ```
 
-#### The subject split schema.
 
-Three sentinel split names are defined for convenience and shared processing:
+## Organization on Disk
 
-1. A training split, named `train`, used for ML model training.
-2. A tuning split, named `tuning`, used for hyperparameter tuning. This is sometimes also called a
-    "validation" split or a "dev" split. In many cases, standardizing on a tuning split is not necessary and
-    models should feel free to merge this split with the training split if desired.
-3. A held-out split, named `held_out`, used for final model evaluation. In many cases, this is also called a
-    "test" split. When performing benchmarking, this split should not be used at all for model selection,
-    training, or for any purposes up to final validation.
+Given a MEDS dataset stored in the `$MEDS_ROOT` directory data of the various schemas outlined above can be
+found in the following subfolders:
 
-Additional split names can be used by the user as desired.
+- `$MEDS_ROOT/data/`: This directory will contain data in the _data_ schema, organized as a
+    series of possibly nested sharded dataframes stored in `parquet` files. In particular, the file glob
+    `glob("$MEDS_ROOT/data/**/*.parquet)` will capture all sharded data files of the raw MEDS data, all
+    organized into _data schema_ files, sharded by subject and sorted, for each subject, by
+    time.
+- `$MEDS_ROOT/metadata/dataset.json`: This schema contains metadata in the _dataset metadata_ schema about
+    the dataset and its production process.
+- `$MEDS_ROOT/metadata/codes.parquet`: This file contains per-code metadata in the _code metadata_ schema
+    about the MEDS dataset. All codes within the dataset should have an entry in this file.
+    As this dataset describes all codes observed in the full MEDS dataset, it is _not_
+    sharded. Note that some pre-processing operations may, at times, produce sharded code metadata files, but
+    these will always appear in subdirectories of `$MEDS_ROOT/metadata/` rather than at the top level, and
+    should generally not be used for overall metadata operations.
+- `$MEDS_ROOT/metadata/subject_splits.parquet`: This schema contains information in the _subject split
+    schema_ about what splits different subjects are in.
 
-```python
-train_split = "train"
-tuning_split = "tuning"
-held_out_split = "held_out"
+
+Task label dataframes are stored in the `label_schema`, in a file path that depends on both a
+`$TASK_ROOT` directory where task label dataframes are stored and a `$TASK_NAME` parameter that separates
+different tasks from one another. In particular, the file glob `glob($TASK_ROOT/$TASK_NAME/**/*.parquet)` will
+retrieve a sharded set of dataframes in the `label_schema` where the sharding may or may not match up with
+the sharding used in the raw `$MEDS_ROOT/data/**/*.parquet` files (e.g., the file
+`$TASK_ROOT/$TASK_NAME/$SHARD_NAME.parquet` may cover the labels for the same set of subjects as are
+contained in the raw data file at `$MEDS_ROOT/data/**/*.parquet`). Note that (1) `$TASK_ROOT` may be a subdir
+of `$MEDS_ROOT` (e.g., often `$TASK_ROOT` will be set to `$MEDS_ROOT/tasks`), (2) `$TASK_NAME` may have `/`s
+in it, thereby rendering the task label directory a deep, nested subdir of `$TASK_ROOT`, and (3) in some
+cases, there may be no task labels for a shard of the raw data, if no subject in that shard qualifies for that
+task, in which case it may be true that either `$TASK_ROOT/$TASK_NAME/$SHARD_NAME.parquet` is empty or that it
+does not exist.
+
+> [!Important]
+> MEDS data must further satisfy two important properties: 
+>
+> 1. Data about a single subject cannot be split across parquet files. If a subject is in a dataset it must be
+>    in one and only one parquet file. 
+> 2. Data about a single subject must be contiguous within a particular parquet file and sorted by time. 
 
 
-class SubjectSplit(PyArrowSchema):
-    """The schema for storing per-subject splits. Stored in `$MEDS_ROOT/metadata/subject_splits.parquet`.
 
-    The subject splits are used to divide the subjects into training, tuning, and held-out sets at a
-    per-subject level. Per-subject splits are currently the only supported split format in MEDS. Additional
-    types of splits may be added in the future; see
-    https://github.com/Medical-Event-Data-Standard/meds/issues/74 for more information and to contribute to
-    the discussion on this point.
 
-    We use the following default split names:
-        - `train`: For training the model.
-        - `tuning`: For hyperparameter tuning, early stopping, etc. This is also commonly called the
-          "validation" or "dev" set.
-        - `held_out`: For final evaluation of the model. This is also commonly called the "test" set.
+## Validation
 
-    This is a PyArrow schema that has
-        - 2 mandatory columns (`subject_id`, `split`)
-        - Extra columns are not allowed.
-
-    Attributes:
-        subject_id: The unique identifier for the subject. This is a 64-bit integer. This field is a join key
-            with the core MEDS data.
-        split: The split for the subject. This is a string. Any value is permissible. The sentinel values of
-            "train", "tuning", and "held_out" are recommended for training, tuning, and held-out sets,
-    """
-
-    allow_extra_columns: ClassVar[bool] = False
-
-    subject_id: pa.int64()
-    split: pa.string()
-```
-
-#### The dataset metadata schema.
+This schema can be used to generate the mandatory schema elements and/or validate or enforce a compliant MEDS
+schema via the `.validate()` method:
 
 ```python
-class DatasetMetadata(JSONSchema):
-    """The schema for the dataset metadata file. Stored in `$MEDS_ROOT/metadata/dataset.json`.
+>>> import pyarrow as pa
+>>> import datetime
+>>> from meds import Data
+>>> Data.schema()
+subject_id: int64
+time: timestamp[us]
+code: string
+numeric_value: float
+>>> data_tbl = pa.Table.from_pydict({
+...     "code": ["A", "B", "C"],
+...     "subject_id": [1, 2, 3],
+...     "time": [
+...         datetime.datetime(2021, 3, 1),
+...         datetime.datetime(2021, 4, 1),
+...         datetime.datetime(2021, 5, 1),
+...     ],
+... })
+>>> Data.validate(data_tbl)
+pyarrow.Table
+subject_id: int64
+time: timestamp[us]
+code: string
+numeric_value: float
+----
+subject_id: [[1,2,3]]
+time: [[2021-03-01 00:00:00.000000,2021-04-01 00:00:00.000000,2021-05-01 00:00:00.000000]]
+code: [["A","B","C"]]
+numeric_value: [[null,null,null]]
 
-    This is a JSON schema that has only optional fields.
-
-    Attributes:
-        dataset_name: The name of the dataset.
-        dataset_version: The version of the dataset.
-        etl_name: The name of the ETL process that generated the dataset.
-        etl_version: The version of the ETL process that generated the dataset.
-        meds_version: The version of the MEDS format.
-        created_at: The datetime the dataset was created. When serialized to JSON, is in ISO 8601 format.
-        license: The license for the dataset.
-        location_uri: The URI for the dataset location.
-        description_uri: The URI for the dataset description.
-        extension_columns: A list of columns in the data beyond those required in the core MEDS data schema.
-    """
-
-    dataset_name: Optional(str) = None
-    dataset_version: Optional(str) = None
-    etl_name: Optional(str) = None
-    etl_version: Optional(str) = None
-    meds_version: Optional(str) = None
-    created_at: Optional(datetime.datetime) = None
-    license: Optional(str) = None
-    location_uri: Optional(str) = None
-    description_uri: Optional(str) = None
-    extension_columns: Optional(list[str]) = None
 ```
+
+
 
 This can be used to generate a JSON schema for the dataset metadata via the `.to_json_schema()` method:
 
@@ -317,7 +408,27 @@ This can be used to generate a JSON schema for the dataset metadata via the `.to
 
 ```
 
-An example for MIMIC-IV would be:
+
+Let's look at the publicly available MIMIC-IV demo dataset for a concrete example of what a MEDS data file may look like.
+
+```python
+┌────────────┬─────────────────────┬──────────────────────┬───────────────┬────────────┬───┐
+│ subject_id ┆ time                ┆ code                 ┆ numeric_value ┆ text_value ┆ … │
+│ ---        ┆ ---                 ┆ ---                  ┆ ---           ┆ ---        ┆   │
+│ i64        ┆ datetime[μs]        ┆ str                  ┆ f32           ┆ str        ┆   │
+╞════════════╪═════════════════════╪══════════════════════╪═══════════════╪════════════╪═══╡
+│ 12345678   ┆ null                ┆ GENDER//M            ┆ null          ┆ null       ┆ … │
+│ 12345678   ┆ 2138-01-01 00:00:00 ┆ MEDS_BIRTH           ┆ null          ┆ null       ┆ … │
+│ 12345678   ┆ 2178-02-12 08:11:00 ┆ LAB//51079//UNK      ┆ null          ┆ POS        ┆ … │
+│ 12345678   ┆ 2178-02-12 11:38:00 ┆ LAB//51237//UNK      ┆ 1.4           ┆ null       ┆ … │
+│ …          ┆ …                   ┆ …                    ┆ …             ┆ …          ┆ … │
+└────────────┴─────────────────────┴──────────────────────┴───────────────┴────────────┴───┘
+```
+
+For each entry, we have the `subject_id` of the person this observation is about, the `time` that the event was recorded, the `code` that describes what this information is about, and some optional fields for the `numeric_value` and/or `text_value` associated with the event.
+
+
+A MEDS-compliant example for MIMIC-IV would be:
 
 ```python
 DatasetMetadata = {
@@ -353,35 +464,4 @@ DatasetMetadata = {
         "statusdescription",
     ],
 }
-```
-
-#### The code metadata schema.
-
-```python
-class CodeMetadata(PyArrowSchema):
-    """The schema for the code metadata file. Stored in `$MEDS_ROOT/metadata/codes.parquet`.
-
-    This file contains additional details about the codes in the MEDS dataset. It is not guaranteed that all
-    unique codes in the dataset will be present in this file. See
-    https://github.com/Medical-Event-Data-Standard/meds/issues/57 if you would like to comment on this design
-    or advocate for mandating that all codes be present in this file.
-
-    This is a PyArrow schema that has
-        - 3 mandatory columns (`code`, `description`, `parent_codes`)
-        - Extra columns are allowed.
-
-    As with all PyArrow schemas, these columns may be null in the data.
-
-    Attributes:
-        code: The code for the event. This is a string (in an unspecified categorical vocabulary). This is a
-            join key with the core MEDS data.
-        description: A human-readable description of the code.
-        parent_codes: A list of string identifiers for "parents" of this code in an ontological sense. These
-            codes may link to other codes in the `codes.parquet` file or to external vocabularies. Most
-            typically, this is used to link to vocabularies in the OMOP CDM.
-    """
-
-    code: pa.string()
-    description: pa.string()
-    parent_codes: pa.list_(pa.string())
 ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ The Medical Event Data Standard (MEDS) is a data schema for storing streams of m
 sourced from either Electronic Health Records or claims records. For more information, tutorials, and
 compatible tools see the website: https://medical-event-data-standard.github.io/.
 
+## Table of Contents
+
+- [Philosophy](#philosophy)
+- [The Schemas](#the-schemas)
+  - [The `Data` schema](#the-data-schema)
+  - [The `DatasetMetadata` schema](#the-datasetmetadata-schema)
+  - [The `CodeMetadata` schema](#the-codemetadata-schema)
+  - [The `SubjectSplit` schema](#the-subjectsplit-schema)
+  - [The `Label` schema](#the-label-schema)
+- [Organization on Disk](#organization-on-disk)
+  - [Organization of task labels](#organization-of-task-labels)
+- [Validation](#validation)
+- [Example: MIMIC-IV demo dataset](#example-mimic-iv-demo-dataset)
+
 ## Philosophy
 
 At the heart of MEDS is a simple yet powerful idea: nearly all EHR data can be modeled as a minimal tuple. We believe that the essence of a clinical event can be effectively described using three core components: 


### PR DESCRIPTION
Following the move to `flexible_schema`, this PR proposes a major update to the repo README. Addresses #72. Looking for feedback, as I am certain there are a lot of things that might still be improved or even reverted to how it was before.

The main changes are: 
* Replaced the "Terminology" section with a new "Philosophy" section that more succinctly states our core idea—that nearly all EHR data can be modeled as a tuple of subject, time, and code.
* Added a Table of Contents at the top for improved navigation, positioned below the header image and badges.
* Revised the "Schemas" section to reflect the new use of `flexible_schema`, keeping a strong focus on "don't panic, this is just PyArrow/JSON with some added functionality".
* Move the "Organization on Disk" section to further done and transform it from a text block to more readable bullet points. 
* Add a "Validation" section with examples of how the `.validate()` method can be used to check for schema compliance.
* Add a "Example" section that shows the MIMIC IV demo dataset in MEDS.

Not yet reflected in this PR:
There is an ongoing discussion that `numeric_value` should be fully optional #78 . This is partially acknowledged in the "Philosophy" section, but since it is not official and implemented yet, the rest of the document still treats `numeric_value` as mandatory but addable. 

Note that there are a lot of tiny commits here that I used to check how the markdown renders on GitHub, so this PR is a strong candidate for a squashed merge.